### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Autism Technology Research Syndicate
 
 # Getting Started
 
->**Note**: Make sure you have completed the [React Native - Environment Setup](https://reactnative.dev/docs/environment-setup) instructions till "Creating a new application" step, before proceeding.
+>**Note**: Make sure you have completed the [React Native - Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) instructions before proceeding. You might need to install the react-native cli if you have not already: `npm i @react-native-community/cli`
 
 ## Step 1: Start the Metro Server
 


### PR DESCRIPTION
it looks like the [previous environment setup page](https://reactnative.dev/docs/environment-setup) now points to installation/getting started instructions using Expo